### PR TITLE
Fix dashboard week view and quick capture logic

### DIFF
--- a/src/components/calendar/AgendaView.tsx
+++ b/src/components/calendar/AgendaView.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { format, isToday, isTomorrow, isYesterday, addDays, startOfToday } from 'date-fns';
 
 interface AgendaViewProps {
-  date: Date;
+  date?: Date;
 }
 
 // Sample data for demonstration
@@ -78,7 +78,7 @@ const groupEventsByDate = (events: typeof sampleEvents): GroupedEvents => {
   }, {});
 };
 
-const AgendaView: React.FC<AgendaViewProps> = ({ date }) => {
+const AgendaView: React.FC<AgendaViewProps> = () => {
   const [expandedEvent, setExpandedEvent] = React.useState<string | null>(null);
   
   // Get a range of 14 days from today

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { format, startOfWeek, addDays, eachHourOfInterval, startOfDay, endOfDay, addHours, isSameDay, isToday } from 'date-fns';
+import { format, startOfWeek, addDays, eachHourOfInterval, startOfDay, addHours, isSameDay, isToday } from 'date-fns';
 
 interface WeekViewProps {
   date: Date;

--- a/src/pages/capture/QuickCapture.tsx
+++ b/src/pages/capture/QuickCapture.tsx
@@ -38,11 +38,11 @@ const QuickCapture: React.FC = () => {
   
   const processInput = async (input: string) => {
     setIsProcessing(true);
-    
+
     // Simulate API call to OpenAI
     setTimeout(() => {
       setResult({
-        title: "Call Sarah about the project proposal",
+        title: input,
         date: "Tomorrow",
         time: "2:00 PM",
         type: "event"

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -55,12 +55,13 @@ const Dashboard: React.FC = () => {
     switch (view) {
       case 'month':
         return format(date, 'MMMM yyyy');
-      case 'week':
-        const startOfWeek = new Date(date);
-        startOfWeek.setDate(date.getDate() - date.getDay());
-        const endOfWeek = new Date(startOfWeek);
-        endOfWeek.setDate(startOfWeek.getDate() + 6);
-        return `${format(startOfWeek, 'MMM d')} - ${format(endOfWeek, 'MMM d, yyyy')}`;
+      case 'week': {
+        const startOfWeekDate = new Date(date);
+        startOfWeekDate.setDate(date.getDate() - date.getDay());
+        const endOfWeekDate = new Date(startOfWeekDate);
+        endOfWeekDate.setDate(startOfWeekDate.getDate() + 6);
+        return `${format(startOfWeekDate, 'MMM d')} - ${format(endOfWeekDate, 'MMM d, yyyy')}`;
+      }
       case 'timeline':
       case 'agenda':
         return format(date, 'EEEE, MMMM d, yyyy');
@@ -150,7 +151,7 @@ const Dashboard: React.FC = () => {
             {view === 'month' && <MonthView date={date} />}
             {view === 'week' && <WeekView date={date} />}
             {view === 'timeline' && <TimelineView date={date} />}
-            {view === 'agenda' && <AgendaView date={date} />}
+            {view === 'agenda' && <AgendaView />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix week view case block in Dashboard to avoid cross-scope vars
- remove unused props from AgendaView
- clean up unused import in WeekView
- pass text into quick capture processing

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f4fa08f608325877e793830d90fc2